### PR TITLE
Use Yarn to install dependencies

### DIFF
--- a/Utilities/NodeInstall/CreateExpressProject
+++ b/Utilities/NodeInstall/CreateExpressProject
@@ -17,11 +17,16 @@ function checkEnvironmentVariable {
 
 checkEnvironmentVariable ELF_TEMPLATES $ELF_TEMPLATES
 
-# Create an express app and run npm install
+# Create an express app
 express --view=pug $1
 cd $1
 
-npm install
+# Install dependencies
+if ! [ -x "$(command -v yarn)" ]; then
+    npm install
+else
+    yarn install
+fi
 
 # Setup bower and bootstrap
 cp $ELF_TEMPLATES/bower.json .


### PR DESCRIPTION
This pull request will install the `express` application's dependencies using `yarn` if it is installed on the user's system. If `yarn` is not installed, it will fallback to using `npm`.