### PR TITLE
Combined dependencies PR

### DIFF
--- a/JavaScript/React/ReactRouterDomNavigate/package-lock.json
+++ b/JavaScript/React/ReactRouterDomNavigate/package-lock.json
@@ -2724,7 +2724,6 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
             "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.0",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2738,7 +2737,6 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
             "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
-            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -2747,22 +2745,28 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
             "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
-            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/source-map": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.11",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-            "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
-            "dev": true
+            "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
             "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -9432,13 +9436,13 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-            "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+            "version": "5.14.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
             "dependencies": {
+                "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
                 "commander": "^2.20.0",
-                "source-map": "~0.7.2",
                 "source-map-support": "~0.5.20"
             },
             "bin": {
@@ -9502,14 +9506,6 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
-        "node_modules/terser/node_modules/source-map": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-            "engines": {
-                "node": ">= 8"
-            }
         },
         "node_modules/test-exclude": {
             "version": "6.0.0",
@@ -12025,7 +12021,6 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
             "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
-            "dev": true,
             "requires": {
                 "@jridgewell/set-array": "^1.0.0",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -12035,26 +12030,31 @@
         "@jridgewell/resolve-uri": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-            "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
-            "dev": true
+            "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew=="
         },
         "@jridgewell/set-array": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-            "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
-            "dev": true
+            "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ=="
+        },
+        "@jridgewell/source-map": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "requires": {
+                "@jridgewell/gen-mapping": "^0.3.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            }
         },
         "@jridgewell/sourcemap-codec": {
             "version": "1.4.11",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-            "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
-            "dev": true
+            "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
         },
         "@jridgewell/trace-mapping": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
             "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-            "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -17078,13 +17078,13 @@
             }
         },
         "terser": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-            "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+            "version": "5.14.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
             "requires": {
+                "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
                 "commander": "^2.20.0",
-                "source-map": "~0.7.2",
                 "source-map-support": "~0.5.20"
             },
             "dependencies": {
@@ -17092,11 +17092,6 @@
                     "version": "2.20.3",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
                     "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-                },
-                "source-map": {
-                    "version": "0.7.3",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
                 }
             }
         },

--- a/JavaScript/React/dynamic-load/package-lock.json
+++ b/JavaScript/React/dynamic-load/package-lock.json
@@ -2725,12 +2725,42 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "dependencies": {
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
             "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/set-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/source-map": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -14325,13 +14355,13 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-            "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+            "version": "5.14.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
             "dependencies": {
+                "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
                 "commander": "^2.20.0",
-                "source-map": "~0.7.2",
                 "source-map-support": "~0.5.20"
             },
             "bin": {
@@ -14386,14 +14416,6 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
-        "node_modules/terser/node_modules/source-map": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-            "engines": {
-                "node": ">= 8"
-            }
         },
         "node_modules/test-exclude": {
             "version": "6.0.0",
@@ -17547,10 +17569,34 @@
                 }
             }
         },
+        "@jridgewell/gen-mapping": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "requires": {
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            }
+        },
         "@jridgewell/resolve-uri": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
             "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew=="
+        },
+        "@jridgewell/set-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+        },
+        "@jridgewell/source-map": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "requires": {
+                "@jridgewell/gen-mapping": "^0.3.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            }
         },
         "@jridgewell/sourcemap-codec": {
             "version": "1.4.11",
@@ -25849,13 +25895,13 @@
             }
         },
         "terser": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-            "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+            "version": "5.14.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
             "requires": {
+                "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
                 "commander": "^2.20.0",
-                "source-map": "~0.7.2",
                 "source-map-support": "~0.5.20"
             },
             "dependencies": {
@@ -25863,11 +25909,6 @@
                     "version": "2.20.3",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
                     "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-                },
-                "source-map": {
-                    "version": "0.7.3",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
                 }
             }
         },


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* bump minimist from 1.2.5 to 1.2.8 in /JavaScript/React/gatsby-site (#737) @dependabot
* Bump socket.io-parser from 3.2.0 to 4.2.2 in /Data/CouchSession (#680) @dependabot
* Bump minimist from 1.2.5 to 1.2.8 in /JavaScript/React/ElfExpressServer/server (#628) @dependabot
* Bump minimist, handlebars, mkdirp, karma and extract-zip in /Data/CouchView02 (#619) @dependabot
* Bump ua-parser-js from 0.7.17 to 0.7.33 in /Data/MongoLabReact01 (#612) @dependabot
* Bump express from 4.17.1 to 4.17.3 in /Data/CouchDb05 (#569) @dependabot
* Bump express from 4.16.4 to 4.18.2 in /JavaScript/NodeCode/PackageEditor/client (#565) @dependabot
* Bump express from 4.16.4 to 4.17.3 in /Data/CouchSession (#561) @dependabot
* Bump express from 4.16.3 to 4.17.3 in /JavaScript/NodeCode/Session04 (#557) @dependabot
* Bump express from 4.16.3 to 4.18.2 in /Data/MongoMultiCollection (#550) @dependabot
* Bump qs from 6.5.2 to 6.5.3 in /JavaScript/Syntax/factory-functions (#541) @dependabot
* Bump express from 4.17.1 to 4.17.3 in /JavaScript/React/ElfExpressServer (#538) @dependabot
* Bump express from 4.16.2 to 4.17.3 in /JavaScript/NodeCode/NodeRoutes01 (#526) @dependabot
* Bump qs from 6.5.1 to 6.11.0 in /JavaScript/React/ElfExpressServer/client (#522) @dependabot
* Bump qs from 6.5.1 to 6.11.0 in /Data/MongoTalk04 (#520) @dependabot
* Bump express from 4.13.4 to 4.17.3 in /JavaScript/Games/CraftyReact (#485) @dependabot
* Bump loader-utils from 0.2.17 to 1.4.2 in /JavaScript/React/ElfExpressServer/client (#450) @dependabot
* Bump loader-utils from 1.4.0 to 1.4.2 in /JavaScript/React/drawer-menu (#439) @dependabot
* Bump socket.io-parser and karma in /JavaScript/Games/CraftyReact (#407) @dependabot
* Bump socket.io-parser and karma in /JavaScript/Games/Crafty08 (#405) @dependabot
* Bump bootstrap from 4.0.0 to 4.3.1 in /Data/MongoBootstrap (#401) @dependabot
* Bump vite from 2.9.12 to 2.9.13 in /JavaScript/Design/MaterialComponents (#399) @dependabot
* Bump terser from 5.12.1 to 5.14.2 in /JavaScript/React/dynamic-load (#397) @dependabot
* Bump terser from 5.12.1 to 5.14.2 in /JavaScript/React/ReactRouterDomNavigate (#395) @dependabot
* Bump terser from 5.12.1 to 5.14.2 in /JavaScript/React/todo-redux (#392) @dependabot
* Bump angular from 1.6.9 to 1.8.3 in /Data/MongoBootstrap (#388) @dependabot
* Bump angular from 1.6.9 to 1.8.3 in /Data/MongoLabAngular02 (#386) @dependabot
